### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ c-types = ["std"]
 lender = ["lazy_static"]
 
 [dependencies]
-log = "^0"
+log = "0.4"
 lazy_static = { version = "^1", optional = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.